### PR TITLE
Basic vote push gossip

### DIFF
--- a/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/AppGossiper.kt
+++ b/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/AppGossiper.kt
@@ -1,5 +1,6 @@
 package nl.tudelft.trustchain.foc
 
+import android.util.Log
 import android.widget.Toast
 import com.frostwire.jlibtorrent.AlertListener
 import com.frostwire.jlibtorrent.SessionManager
@@ -277,6 +278,7 @@ class AppGossiper(
 
     private suspend fun iterativelyFetchVotes() {
         while (scope.isActive) {
+            Log.i("vote-gossip", "Fetching votes, size: ${focCommunity.voteMessagesList.size}")
             for ((_, payload) in ArrayList(focCommunity.voteMessagesList)) {
                 voteTracker?.insertVote(payload.fileName, payload.focVote)
             }

--- a/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/AppGossiper.kt
+++ b/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/AppGossiper.kt
@@ -1,6 +1,5 @@
 package nl.tudelft.trustchain.foc
 
-import android.util.Log
 import android.widget.Toast
 import com.frostwire.jlibtorrent.AlertListener
 import com.frostwire.jlibtorrent.SessionManager
@@ -28,7 +27,6 @@ import nl.tudelft.ipv8.messaging.eva.TransferType
 import nl.tudelft.trustchain.common.freedomOfComputing.AppPayload
 import nl.tudelft.trustchain.foc.community.FOCCommunityBase
 import nl.tudelft.trustchain.foc.community.FOCMessage
-import nl.tudelft.trustchain.foc.community.FOCVoteTracker
 import nl.tudelft.trustchain.foc.util.ExtensionUtils.Companion.APK_EXTENSION
 import nl.tudelft.trustchain.foc.util.ExtensionUtils.Companion.TORRENT_EXTENSION
 import nl.tudelft.trustchain.foc.util.ExtensionUtils.Companion.supportedAppExtensions
@@ -61,8 +59,7 @@ class AppGossiper(
     private val sessionManager: SessionManager,
     private val activity: MainActivityFOC,
     private val focCommunity: FOCCommunityBase,
-    private val toastingEnabled: Boolean,
-    private val voteTracker: FOCVoteTracker?
+    private val toastingEnabled: Boolean
 ) {
     private val scope = CoroutineScope(Dispatchers.IO)
     private var evaDownload: EvaDownload = EvaDownload()
@@ -84,8 +81,7 @@ class AppGossiper(
             sessionManager: SessionManager,
             activity: MainActivityFOC,
             focCommunity: FOCCommunityBase,
-            toastingEnabled: Boolean = true,
-            voteTracker: FOCVoteTracker? = null
+            toastingEnabled: Boolean = true
         ): AppGossiper {
             if (!::appGossiperInstance.isInitialized) {
                 appGossiperInstance =
@@ -93,8 +89,7 @@ class AppGossiper(
                         sessionManager,
                         activity,
                         focCommunity,
-                        toastingEnabled,
-                        voteTracker
+                        toastingEnabled
                     )
             }
             return appGossiperInstance
@@ -119,9 +114,6 @@ class AppGossiper(
         }
         scope.launch {
             iterativelyDownloadApps()
-        }
-        scope.launch {
-            iterativelyFetchVotes()
         }
     }
 
@@ -271,16 +263,6 @@ class AppGossiper(
                 } catch (e: Exception) {
                     activity.runOnUiThread { printToast(e.toString()) }
                 }
-            }
-            delay(DOWNLOAD_DELAY)
-        }
-    }
-
-    private suspend fun iterativelyFetchVotes() {
-        while (scope.isActive) {
-            Log.i("vote-gossip", "Fetching votes, size: ${focCommunity.voteMessagesList.size}")
-            for ((_, payload) in ArrayList(focCommunity.voteMessagesList)) {
-                voteTracker?.insertVote(payload.fileName, payload.focVote)
             }
             delay(DOWNLOAD_DELAY)
         }

--- a/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/AppGossiper.kt
+++ b/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/AppGossiper.kt
@@ -27,6 +27,7 @@ import nl.tudelft.ipv8.messaging.eva.TransferType
 import nl.tudelft.trustchain.common.freedomOfComputing.AppPayload
 import nl.tudelft.trustchain.foc.community.FOCCommunityBase
 import nl.tudelft.trustchain.foc.community.FOCMessage
+import nl.tudelft.trustchain.foc.community.FOCVoteTracker
 import nl.tudelft.trustchain.foc.util.ExtensionUtils.Companion.APK_EXTENSION
 import nl.tudelft.trustchain.foc.util.ExtensionUtils.Companion.TORRENT_EXTENSION
 import nl.tudelft.trustchain.foc.util.ExtensionUtils.Companion.supportedAppExtensions
@@ -59,7 +60,8 @@ class AppGossiper(
     private val sessionManager: SessionManager,
     private val activity: MainActivityFOC,
     private val focCommunity: FOCCommunityBase,
-    private val toastingEnabled: Boolean
+    private val toastingEnabled: Boolean,
+    private val voteTracker: FOCVoteTracker?
 ) {
     private val scope = CoroutineScope(Dispatchers.IO)
     private var evaDownload: EvaDownload = EvaDownload()
@@ -81,11 +83,18 @@ class AppGossiper(
             sessionManager: SessionManager,
             activity: MainActivityFOC,
             focCommunity: FOCCommunityBase,
-            toastingEnabled: Boolean = true
+            toastingEnabled: Boolean = true,
+            voteTracker: FOCVoteTracker? = null
         ): AppGossiper {
             if (!::appGossiperInstance.isInitialized) {
                 appGossiperInstance =
-                    AppGossiper(sessionManager, activity, focCommunity, toastingEnabled)
+                    AppGossiper(
+                        sessionManager,
+                        activity,
+                        focCommunity,
+                        toastingEnabled,
+                        voteTracker
+                    )
             }
             return appGossiperInstance
         }
@@ -109,6 +118,9 @@ class AppGossiper(
         }
         scope.launch {
             iterativelyDownloadApps()
+        }
+        scope.launch {
+            iterativelyFetchVotes()
         }
     }
 
@@ -258,6 +270,15 @@ class AppGossiper(
                 } catch (e: Exception) {
                     activity.runOnUiThread { printToast(e.toString()) }
                 }
+            }
+            delay(DOWNLOAD_DELAY)
+        }
+    }
+
+    private suspend fun iterativelyFetchVotes() {
+        while (scope.isActive) {
+            for ((_, payload) in ArrayList(focCommunity.voteMessagesList)) {
+                voteTracker?.insertVote(payload.fileName, payload.focVote)
             }
             delay(DOWNLOAD_DELAY)
         }

--- a/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/MainActivityFOC.kt
+++ b/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/MainActivityFOC.kt
@@ -1,6 +1,5 @@
 package nl.tudelft.trustchain.foc
 
-import android.annotation.SuppressLint
 import android.app.AlertDialog
 import android.content.Intent
 import android.content.res.ColorStateList

--- a/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/MainActivityFOC.kt
+++ b/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/MainActivityFOC.kt
@@ -66,7 +66,8 @@ open class MainActivityFOC : AppCompatActivity() {
     private var bufferSize = 1024 * 5
     private val s = SessionManager()
     private var torrentAmount = 0
-    private val voteTracker: FOCVoteTracker = FOCVoteTracker(this)
+    private val voteTracker: FOCVoteTracker? =
+        IPv8Android.getInstance().getOverlay<FOCCommunity>()?.let { FOCVoteTracker(this, it) }
     private var appGossiper: AppGossiper? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -98,13 +99,13 @@ open class MainActivityFOC : AppCompatActivity() {
             }
 
             binding.torrentCount.text = getString(R.string.torrentCount, torrentAmount)
-            voteTracker.loadState()
+            voteTracker?.loadState()
             copyDefaultApp()
             showAllFiles()
 
             appGossiper =
                 IPv8Android.getInstance().getOverlay<FOCCommunity>()
-                    ?.let { AppGossiper.getInstance(s, this, it) }
+                    ?.let { AppGossiper.getInstance(s, this, it, voteTracker = voteTracker) }
             appGossiper?.start()
         } catch (e: Exception) {
             printToast(e.toString())
@@ -158,7 +159,7 @@ open class MainActivityFOC : AppCompatActivity() {
     override fun onPause() {
         super.onPause()
         appGossiper?.pause()
-        voteTracker.storeState()
+        voteTracker?.storeState()
     }
 
     private fun showAllFiles() {
@@ -257,7 +258,7 @@ open class MainActivityFOC : AppCompatActivity() {
             row.addView(button)
         }
         val upVote = Button(this)
-        upVote.text = getString(R.string.upVote, voteTracker.getNumberOfVotes(fileName, VoteType.UP))
+        upVote.text = getString(R.string.upVote, voteTracker?.getNumberOfVotes(fileName, VoteType.UP))
         val upVoteParams: RelativeLayout.LayoutParams =
             RelativeLayout.LayoutParams(
                 RelativeLayout.LayoutParams.WRAP_CONTENT,
@@ -269,7 +270,7 @@ open class MainActivityFOC : AppCompatActivity() {
         row.addView(upVote)
 
         val downVote = Button(this)
-        downVote.text = getString(R.string.downVote, voteTracker.getNumberOfVotes(fileName, VoteType.DOWN))
+        downVote.text = getString(R.string.downVote, voteTracker?.getNumberOfVotes(fileName, VoteType.DOWN))
         downVote.backgroundTintList =
             ColorStateList.valueOf(ContextCompat.getColor(applicationContext, R.color.red))
         row.addView(downVote)
@@ -281,11 +282,11 @@ open class MainActivityFOC : AppCompatActivity() {
         binding.torrentCount.text = getString(R.string.torrentCount, ++torrentAmount)
         upVote.setOnClickListener {
             placeVote(fileName, VoteType.UP)
-            upVote.text = getString(R.string.upVote, voteTracker.getNumberOfVotes(fileName, VoteType.UP))
+            upVote.text = getString(R.string.upVote, voteTracker?.getNumberOfVotes(fileName, VoteType.UP))
         }
         downVote.setOnClickListener {
             placeVote(fileName, VoteType.DOWN)
-            downVote.text = getString(R.string.downVote, voteTracker.getNumberOfVotes(fileName, VoteType.DOWN))
+            downVote.text = getString(R.string.downVote, voteTracker?.getNumberOfVotes(fileName, VoteType.DOWN))
         }
         button.setOnClickListener {
             loadDynamicCode(fileName)
@@ -308,8 +309,8 @@ open class MainActivityFOC : AppCompatActivity() {
     private fun createAlertDialog(fileName: String) {
         val builder: AlertDialog.Builder = AlertDialog.Builder(this)
         builder.setTitle(getString(R.string.createAlertDialogTitle))
-        val upVoteCount = voteTracker.getNumberOfVotes(fileName, VoteType.UP)
-        val downVoteCount = voteTracker.getNumberOfVotes(fileName, VoteType.DOWN)
+        val upVoteCount = voteTracker?.getNumberOfVotes(fileName, VoteType.UP)
+        val downVoteCount = voteTracker?.getNumberOfVotes(fileName, VoteType.DOWN)
         builder.setMessage(getString(R.string.createAlertDialogMsg, upVoteCount, downVoteCount))
         builder.setPositiveButton(getString(R.string.cancelButton), null)
         builder.setNeutralButton(getString(R.string.deleteButton)) { _, _ -> deleteApkFile(fileName) }
@@ -392,7 +393,7 @@ open class MainActivityFOC : AppCompatActivity() {
             val ipv8 = IPv8Android.getInstance()
             val memberId = ipv8.myPeer.mid
 
-            voteTracker.vote(fileName, FOCVote(memberId, voteType))
+            voteTracker?.vote(fileName, FOCVote(memberId, voteType))
         } else {
             printToast("Couldn't find file '$fileName'")
         }

--- a/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/MainActivityFOC.kt
+++ b/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/MainActivityFOC.kt
@@ -1,5 +1,6 @@
 package nl.tudelft.trustchain.foc
 
+import android.annotation.SuppressLint
 import android.app.AlertDialog
 import android.content.Intent
 import android.content.res.ColorStateList
@@ -20,6 +21,7 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
+import androidx.core.view.allViews
 import com.frostwire.jlibtorrent.SessionManager
 import com.frostwire.jlibtorrent.TorrentInfo
 import com.frostwire.jlibtorrent.Vectors
@@ -243,6 +245,7 @@ open class MainActivityFOC : AppCompatActivity() {
         val row = LinearLayout(this)
 
         var button = Button(this)
+        button.id = R.id.apkNameId
         val fileName = getFileName(uri)
         button.text = fileName
         button.layoutParams =
@@ -259,6 +262,7 @@ open class MainActivityFOC : AppCompatActivity() {
             row.addView(button)
         }
         val upVote = Button(this)
+        upVote.id = R.id.upVoteId
         upVote.text =
             getString(R.string.upVote, voteTracker?.getNumberOfVotes(fileName, VoteType.UP))
         val upVoteParams: RelativeLayout.LayoutParams =
@@ -272,6 +276,7 @@ open class MainActivityFOC : AppCompatActivity() {
         row.addView(upVote)
 
         val downVote = Button(this)
+        downVote.id = R.id.downVoteId
         downVote.text =
             getString(R.string.downVote, voteTracker?.getNumberOfVotes(fileName, VoteType.DOWN))
         downVote.backgroundTintList =
@@ -300,6 +305,21 @@ open class MainActivityFOC : AppCompatActivity() {
             createAlertDialog(fileName)
             true
         }
+    }
+
+    fun updateVoteCounts(fileName: String) {
+        val torrentListView = binding.contentMainActivityFocLayout.torrentList
+        val row =
+            torrentListView.allViews.find { v -> v is LinearLayout && v.allViews.any { b -> b is Button && b.text == fileName } }
+                ?: return
+
+        val upVote = row.findViewById<Button>(R.id.upVoteId)
+        upVote.text =
+            getString(R.string.upVote, voteTracker?.getNumberOfVotes(fileName, VoteType.UP))
+
+        val downVote = row.findViewById<Button>(R.id.downVoteId)
+        downVote.text =
+            getString(R.string.downVote, voteTracker?.getNumberOfVotes(fileName, VoteType.DOWN))
     }
 
     fun createUnsuccessfulTorrentButton(torrentName: String) {

--- a/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/MainActivityFOC.kt
+++ b/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/MainActivityFOC.kt
@@ -100,12 +100,13 @@ open class MainActivityFOC : AppCompatActivity() {
 
             binding.torrentCount.text = getString(R.string.torrentCount, torrentAmount)
             voteTracker?.loadState()
+            voteTracker?.start()
             copyDefaultApp()
             showAllFiles()
 
             appGossiper =
                 IPv8Android.getInstance().getOverlay<FOCCommunity>()
-                    ?.let { AppGossiper.getInstance(s, this, it, voteTracker = voteTracker) }
+                    ?.let { AppGossiper.getInstance(s, this, it) }
             appGossiper?.start()
         } catch (e: Exception) {
             printToast(e.toString())
@@ -258,7 +259,8 @@ open class MainActivityFOC : AppCompatActivity() {
             row.addView(button)
         }
         val upVote = Button(this)
-        upVote.text = getString(R.string.upVote, voteTracker?.getNumberOfVotes(fileName, VoteType.UP))
+        upVote.text =
+            getString(R.string.upVote, voteTracker?.getNumberOfVotes(fileName, VoteType.UP))
         val upVoteParams: RelativeLayout.LayoutParams =
             RelativeLayout.LayoutParams(
                 RelativeLayout.LayoutParams.WRAP_CONTENT,
@@ -270,7 +272,8 @@ open class MainActivityFOC : AppCompatActivity() {
         row.addView(upVote)
 
         val downVote = Button(this)
-        downVote.text = getString(R.string.downVote, voteTracker?.getNumberOfVotes(fileName, VoteType.DOWN))
+        downVote.text =
+            getString(R.string.downVote, voteTracker?.getNumberOfVotes(fileName, VoteType.DOWN))
         downVote.backgroundTintList =
             ColorStateList.valueOf(ContextCompat.getColor(applicationContext, R.color.red))
         row.addView(downVote)
@@ -282,11 +285,13 @@ open class MainActivityFOC : AppCompatActivity() {
         binding.torrentCount.text = getString(R.string.torrentCount, ++torrentAmount)
         upVote.setOnClickListener {
             placeVote(fileName, VoteType.UP)
-            upVote.text = getString(R.string.upVote, voteTracker?.getNumberOfVotes(fileName, VoteType.UP))
+            upVote.text =
+                getString(R.string.upVote, voteTracker?.getNumberOfVotes(fileName, VoteType.UP))
         }
         downVote.setOnClickListener {
             placeVote(fileName, VoteType.DOWN)
-            downVote.text = getString(R.string.downVote, voteTracker?.getNumberOfVotes(fileName, VoteType.DOWN))
+            downVote.text =
+                getString(R.string.downVote, voteTracker?.getNumberOfVotes(fileName, VoteType.DOWN))
         }
         button.setOnClickListener {
             loadDynamicCode(fileName)
@@ -365,7 +370,8 @@ open class MainActivityFOC : AppCompatActivity() {
             }?.delete()
 
             if (deleted != null && deleted) {
-                val buttonToBeDeleted = torrentMap.entries.find { entry -> entry.key.text == fileName }?.key
+                val buttonToBeDeleted =
+                    torrentMap.entries.find { entry -> entry.key.text == fileName }?.key
 
                 if (buttonToBeDeleted != null) {
                     val torrentListView = binding.contentMainActivityFocLayout.torrentList

--- a/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/MainActivityFOC.kt
+++ b/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/MainActivityFOC.kt
@@ -323,10 +323,18 @@ open class MainActivityFOC : AppCompatActivity() {
 
     fun createUnsuccessfulTorrentButton(torrentName: String) {
         val torrentListView = binding.contentMainActivityFocLayout.torrentList
+        val row = LinearLayout(this)
         val button = Button(this)
+        button.id = R.id.apkNameId
         button.text = torrentName
+        button.layoutParams =
+            RelativeLayout.LayoutParams(
+                600,
+                RelativeLayout.LayoutParams.MATCH_PARENT
+            )
         torrentMap[button] = LinearLayout(this)
-        torrentListView.addView(button)
+        row.addView(button)
+        torrentListView.addView(row)
         button.isAllCaps = false
     }
 

--- a/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCCommunity.kt
+++ b/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCCommunity.kt
@@ -108,12 +108,14 @@ class FOCCommunity(
             "Informing about ${vote.voteType} vote on $fileName from ${vote.memberId}"
         )
         for (peer in getPeers()) {
+            Log.i("vote-gossip", "Sending vote to ${peer.mid}")
             val packet =
                 serializePacket(
                     MessageId.VOTE_MESSAGE,
                     FOCVoteMessage(fileName, vote),
                     true
                 )
+            Log.i("vote-gossip", "Address: ${peer.address}, packet: $packet")
             send(peer.address, packet)
         }
     }
@@ -132,9 +134,9 @@ class FOCCommunity(
     init {
         messageHandlers[MessageId.FOC_THALIS_MESSAGE] = ::onMessage
         messageHandlers[MessageId.TORRENT_MESSAGE] = ::onTorrentMessage
+        messageHandlers[MessageId.VOTE_MESSAGE] = ::onVoteMessage
         messageHandlers[MessageId.APP_REQUEST] = ::onAppRequestPacket
         messageHandlers[MessageId.APP] = ::onAppPacket
-        messageHandlers[MessageId.VOTE_MESSAGE] = ::onVoteMessage
         evaProtocolEnabled = true
     }
 
@@ -169,6 +171,7 @@ class FOCCommunity(
     }
 
     private fun onVoteMessage(packet: Packet) {
+        Log.i("vote-gossip", "OnVoteMessage Called")
         val (peer, payload) = packet.getAuthPayload(FOCVoteMessage)
         Log.i(
             "vote-gossip",

--- a/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCCommunity.kt
+++ b/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCCommunity.kt
@@ -78,7 +78,7 @@ class FOCCommunity(
     }
 
     override var torrentMessagesList = ArrayList<Pair<Peer, FOCMessage>>()
-    override var voteMessagesList = ArrayList<Pair<Peer, FOCVoteMessage>>()
+    override var voteMessagesQueue: Queue<Pair<Peer, FOCVoteMessage>> = LinkedList()
 
     object MessageId {
         const val FOC_THALIS_MESSAGE = 220
@@ -161,7 +161,8 @@ class FOCCommunity(
                 .substringBefore("&dn=")
         if (torrentMessagesList.none {
                 it.second
-                val existingHash = it.second.message.substringAfter("magnet:?xt=urn:btih:").substringBefore("&dn=")
+                val existingHash =
+                    it.second.message.substringAfter("magnet:?xt=urn:btih:").substringBefore("&dn=")
                 torrentHash == existingHash
             }
         ) {
@@ -170,6 +171,7 @@ class FOCCommunity(
         }
     }
 
+
     private fun onVoteMessage(packet: Packet) {
         Log.i("vote-gossip", "OnVoteMessage Called")
         val (peer, payload) = packet.getAuthPayload(FOCVoteMessage)
@@ -177,13 +179,7 @@ class FOCCommunity(
             "vote-gossip",
             "Received vote message from ${peer.mid} for file ${payload.fileName} and direction ${payload.focVote.voteType}"
         )
-        if (voteMessagesList.none {
-                it.second
-                it.second.fileName == payload.fileName && it.second.focVote.memberId == payload.focVote.memberId
-            }) {
-            voteMessagesList.add(Pair(peer, payload))
-            Log.i("vote-gossip", peer.mid + ": " + payload.fileName)
-        }
+        voteMessagesQueue.add(Pair(peer, payload))
     }
 
     private fun onAppRequestPacket(packet: Packet) {

--- a/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCCommunity.kt
+++ b/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCCommunity.kt
@@ -179,7 +179,11 @@ class FOCCommunity(
             "vote-gossip",
             "Received vote message from ${peer.mid} for file ${payload.fileName} and direction ${payload.focVote.voteType}"
         )
-        voteMessagesQueue.add(Pair(peer, payload))
+        if (voteMessagesQueue.none {
+                it.second == payload
+            }) {
+            voteMessagesQueue.add(Pair(peer, payload))
+        }
     }
 
     private fun onAppRequestPacket(packet: Packet) {

--- a/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCCommunity.kt
+++ b/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCCommunity.kt
@@ -102,7 +102,10 @@ class FOCCommunity(
         }
     }
 
-    override fun informAboutVote(fileName: String, vote: FOCVote) {
+    override fun informAboutVote(
+        fileName: String,
+        vote: FOCVote
+    ) {
         Log.i(
             "vote-gossip",
             "Informing about ${vote.voteType} vote on $fileName from ${vote.memberId}"
@@ -171,7 +174,6 @@ class FOCCommunity(
         }
     }
 
-
     private fun onVoteMessage(packet: Packet) {
         Log.i("vote-gossip", "OnVoteMessage Called")
         val (peer, payload) = packet.getAuthPayload(FOCVoteMessage)
@@ -181,7 +183,8 @@ class FOCCommunity(
         )
         if (voteMessagesQueue.none {
                 it.second == payload
-            }) {
+            }
+        ) {
             voteMessagesQueue.add(Pair(peer, payload))
         }
     }

--- a/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCCommunityBase.kt
+++ b/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCCommunityBase.kt
@@ -21,7 +21,8 @@ abstract class FOCCommunityBase : Community() {
 
     abstract fun informAboutVote(
         fileName: String,
-        vote: FOCVote
+        vote: FOCVote,
+        ttl: UInt
     )
 
     abstract fun sendAppRequest(

--- a/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCCommunityBase.kt
+++ b/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCCommunityBase.kt
@@ -9,8 +9,7 @@ import kotlin.collections.ArrayList
 
 abstract class FOCCommunityBase : Community() {
     abstract var torrentMessagesList: ArrayList<Pair<Peer, FOCMessage>>
-    abstract var voteMessagesList: ArrayList<Pair<Peer, FOCVoteMessage>>
-
+    abstract var voteMessagesQueue: Queue<Pair<Peer, FOCVoteMessage>>
     abstract fun setEVAOnReceiveProgressCallback(f: (peer: Peer, info: String, progress: TransferProgress) -> Unit)
 
     abstract fun setEVAOnReceiveCompleteCallback(f: (peer: Peer, info: String, id: String, data: ByteArray?) -> Unit)

--- a/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCCommunityBase.kt
+++ b/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCCommunityBase.kt
@@ -10,6 +10,7 @@ import kotlin.collections.ArrayList
 abstract class FOCCommunityBase : Community() {
     abstract var torrentMessagesList: ArrayList<Pair<Peer, FOCMessage>>
     abstract var voteMessagesQueue: Queue<Pair<Peer, FOCVoteMessage>>
+
     abstract fun setEVAOnReceiveProgressCallback(f: (peer: Peer, info: String, progress: TransferProgress) -> Unit)
 
     abstract fun setEVAOnReceiveCompleteCallback(f: (peer: Peer, info: String, id: String, data: ByteArray?) -> Unit)
@@ -18,7 +19,10 @@ abstract class FOCCommunityBase : Community() {
 
     abstract fun informAboutTorrent(torrentName: String)
 
-    abstract fun informAboutVote(fileName: String, vote: FOCVote)
+    abstract fun informAboutVote(
+        fileName: String,
+        vote: FOCVote
+    )
 
     abstract fun sendAppRequest(
         torrentInfoHash: String,

--- a/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCCommunityBase.kt
+++ b/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCCommunityBase.kt
@@ -5,9 +5,11 @@ import nl.tudelft.ipv8.Peer
 import nl.tudelft.ipv8.messaging.eva.TransferException
 import nl.tudelft.ipv8.messaging.eva.TransferProgress
 import java.util.*
+import kotlin.collections.ArrayList
 
 abstract class FOCCommunityBase : Community() {
     abstract var torrentMessagesList: ArrayList<Pair<Peer, FOCMessage>>
+    abstract var voteMessagesList: ArrayList<Pair<Peer, FOCVoteMessage>>
 
     abstract fun setEVAOnReceiveProgressCallback(f: (peer: Peer, info: String, progress: TransferProgress) -> Unit)
 
@@ -16,6 +18,8 @@ abstract class FOCCommunityBase : Community() {
     abstract fun setEVAOnErrorCallback(f: (peer: Peer, exception: TransferException) -> Unit)
 
     abstract fun informAboutTorrent(torrentName: String)
+
+    abstract fun informAboutVote(fileName: String, vote: FOCVote)
 
     abstract fun sendAppRequest(
         torrentInfoHash: String,

--- a/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCVote.kt
+++ b/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCVote.kt
@@ -1,8 +1,5 @@
 package nl.tudelft.trustchain.foc.community
 
-import nl.tudelft.ipv8.messaging.Deserializable
-import nl.tudelft.ipv8.messaging.deserializeVarLen
-import nl.tudelft.ipv8.messaging.serializeVarLen
 import java.io.Serializable
 
 enum class VoteType {
@@ -10,30 +7,4 @@ enum class VoteType {
     DOWN
 }
 
-data class FOCVote(val memberId: String, val voteType: VoteType) :
-    Serializable,
-    nl.tudelft.ipv8.messaging.Serializable {
-    override fun serialize(): ByteArray {
-        return serializeVarLen(memberId.toByteArray(Charsets.UTF_8)) +
-            serializeVarLen(voteType.toString().toByteArray(Charsets.UTF_8))
-    }
-
-    companion object Deserializer : Deserializable<FOCVote> {
-        override fun deserialize(
-            buffer: ByteArray,
-            offset: Int
-        ): Pair<FOCVote, Int> {
-            var localOffset = offset
-            val (mid, midSize) = deserializeVarLen(buffer, localOffset)
-            localOffset += midSize
-            val (voteType, voteTypeSize) = deserializeVarLen(buffer, localOffset)
-            localOffset += voteTypeSize
-            val payload =
-                FOCVote(
-                    mid.toString(Charsets.UTF_8),
-                    VoteType.valueOf(voteType.toString(Charsets.UTF_8))
-                )
-            return Pair(payload, localOffset - offset)
-        }
-    }
-}
+data class FOCVote(val memberId: String, val voteType: VoteType) : Serializable

--- a/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCVote.kt
+++ b/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCVote.kt
@@ -1,10 +1,8 @@
 package nl.tudelft.trustchain.foc.community
 
 import nl.tudelft.ipv8.messaging.Deserializable
-import java.io.ByteArrayInputStream
-import java.io.ByteArrayOutputStream
-import java.io.ObjectInputStream
-import java.io.ObjectOutputStream
+import nl.tudelft.ipv8.messaging.deserializeVarLen
+import nl.tudelft.ipv8.messaging.serializeVarLen
 import java.io.Serializable
 
 enum class VoteType {
@@ -12,24 +10,29 @@ enum class VoteType {
     DOWN
 }
 
-data class FOCVote(val memberId: String, val voteType: VoteType) : Serializable, nl.tudelft.ipv8.messaging.Serializable {
+data class FOCVote(val memberId: String, val voteType: VoteType) : Serializable,
+    nl.tudelft.ipv8.messaging.Serializable {
     override fun serialize(): ByteArray {
-        val byteArrayOutputStream = ByteArrayOutputStream()
-        val objectOutputStream = ObjectOutputStream(byteArrayOutputStream)
-        objectOutputStream.writeObject(this)
-        objectOutputStream.flush()
-        return byteArrayOutputStream.toByteArray()
+        return serializeVarLen(memberId.toByteArray(Charsets.UTF_8)) +
+            serializeVarLen(voteType.toString().toByteArray(Charsets.UTF_8))
     }
 
-    @Suppress("UNCHECKED_CAST")
     companion object Deserializer : Deserializable<FOCVote> {
         override fun deserialize(
             buffer: ByteArray,
             offset: Int
         ): Pair<FOCVote, Int> {
-            val byteArrayInputStream = ByteArrayInputStream(buffer)
-            val objectInputStream = ObjectInputStream(byteArrayInputStream)
-            return Pair(objectInputStream.readObject() as FOCVote, buffer.size)
+            var localOffset = offset;
+            val (mid, midSize) = deserializeVarLen(buffer, localOffset)
+            localOffset += midSize
+            val (voteType, voteTypeSize) = deserializeVarLen(buffer, localOffset)
+            localOffset += voteTypeSize
+            val payload =
+                FOCVote(
+                    mid.toString(Charsets.UTF_8),
+                    VoteType.valueOf(voteType.toString(Charsets.UTF_8))
+                )
+            return Pair(payload, localOffset - offset)
         }
     }
 }

--- a/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCVote.kt
+++ b/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCVote.kt
@@ -10,7 +10,8 @@ enum class VoteType {
     DOWN
 }
 
-data class FOCVote(val memberId: String, val voteType: VoteType) : Serializable,
+data class FOCVote(val memberId: String, val voteType: VoteType) :
+    Serializable,
     nl.tudelft.ipv8.messaging.Serializable {
     override fun serialize(): ByteArray {
         return serializeVarLen(memberId.toByteArray(Charsets.UTF_8)) +
@@ -22,7 +23,7 @@ data class FOCVote(val memberId: String, val voteType: VoteType) : Serializable,
             buffer: ByteArray,
             offset: Int
         ): Pair<FOCVote, Int> {
-            var localOffset = offset;
+            var localOffset = offset
             val (mid, midSize) = deserializeVarLen(buffer, localOffset)
             localOffset += midSize
             val (voteType, voteTypeSize) = deserializeVarLen(buffer, localOffset)

--- a/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCVote.kt
+++ b/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCVote.kt
@@ -1,5 +1,10 @@
 package nl.tudelft.trustchain.foc.community
 
+import nl.tudelft.ipv8.messaging.Deserializable
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
 import java.io.Serializable
 
 enum class VoteType {
@@ -7,4 +12,24 @@ enum class VoteType {
     DOWN
 }
 
-data class FOCVote(val memberId: String, val voteType: VoteType) : Serializable
+data class FOCVote(val memberId: String, val voteType: VoteType) : Serializable, nl.tudelft.ipv8.messaging.Serializable {
+    override fun serialize(): ByteArray {
+        val byteArrayOutputStream = ByteArrayOutputStream()
+        val objectOutputStream = ObjectOutputStream(byteArrayOutputStream)
+        objectOutputStream.writeObject(this)
+        objectOutputStream.flush()
+        return byteArrayOutputStream.toByteArray()
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    companion object Deserializer : Deserializable<FOCVote> {
+        override fun deserialize(
+            buffer: ByteArray,
+            offset: Int
+        ): Pair<FOCVote, Int> {
+            val byteArrayInputStream = ByteArrayInputStream(buffer)
+            val objectInputStream = ObjectInputStream(byteArrayInputStream)
+            return Pair(objectInputStream.readObject() as FOCVote, buffer.size)
+        }
+    }
+}

--- a/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCVoteMessage.kt
+++ b/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCVoteMessage.kt
@@ -1,17 +1,21 @@
 package nl.tudelft.trustchain.foc.community
 
 import nl.tudelft.ipv8.messaging.Deserializable
+import nl.tudelft.ipv8.messaging.SERIALIZED_UINT_SIZE
+import nl.tudelft.ipv8.messaging.deserializeUInt
 import nl.tudelft.ipv8.messaging.deserializeVarLen
+import nl.tudelft.ipv8.messaging.serializeUInt
 import nl.tudelft.ipv8.messaging.serializeVarLen
 import java.io.Serializable
 
-data class FOCVoteMessage(val fileName: String, val focVote: FOCVote) :
+data class FOCVoteMessage(val fileName: String, val focVote: FOCVote, val TTL: UInt) :
     Serializable,
     nl.tudelft.ipv8.messaging.Serializable {
     override fun serialize(): ByteArray {
         return serializeVarLen(fileName.toByteArray(Charsets.UTF_8)) +
             serializeVarLen(focVote.memberId.toByteArray(Charsets.UTF_8)) +
-            serializeVarLen(focVote.voteType.toString().toByteArray(Charsets.UTF_8))
+            serializeVarLen(focVote.voteType.toString().toByteArray(Charsets.UTF_8)) +
+            serializeUInt(TTL)
     }
 
     companion object Deserializer : Deserializable<FOCVoteMessage> {
@@ -26,13 +30,16 @@ data class FOCVoteMessage(val fileName: String, val focVote: FOCVote) :
             localOffset += midSize
             val (voteType, voteTypeSize) = deserializeVarLen(buffer, localOffset)
             localOffset += voteTypeSize
+            val ttl = deserializeUInt(buffer, localOffset)
+            localOffset += SERIALIZED_UINT_SIZE
             val payload =
                 FOCVoteMessage(
                     fileName.toString(Charsets.UTF_8),
                     FOCVote(
                         mid.toString(Charsets.UTF_8),
                         VoteType.valueOf(voteType.toString(Charsets.UTF_8))
-                    )
+                    ),
+                    ttl
                 )
             return Pair(payload, localOffset - offset)
         }

--- a/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCVoteMessage.kt
+++ b/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCVoteMessage.kt
@@ -1,0 +1,19 @@
+package nl.tudelft.trustchain.foc.community
+
+import nl.tudelft.ipv8.messaging.Deserializable
+import java.io.Serializable
+
+data class FOCVoteMessage(val fileName: String, val focVote: FOCVote) : Serializable, nl.tudelft.ipv8.messaging.Serializable {
+    override fun serialize(): ByteArray {
+        return this.serialize()
+    }
+
+    companion object Deserializer : Deserializable<FOCVoteMessage> {
+        override fun deserialize(
+            buffer: ByteArray,
+            offset: Int
+        ): Pair<FOCVoteMessage, Int> {
+            return this.deserialize(buffer)
+        }
+    }
+}

--- a/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCVoteMessage.kt
+++ b/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCVoteMessage.kt
@@ -5,7 +5,8 @@ import nl.tudelft.ipv8.messaging.deserializeVarLen
 import nl.tudelft.ipv8.messaging.serializeVarLen
 import java.io.Serializable
 
-data class FOCVoteMessage(val fileName: String, val focVote: FOCVote) : Serializable,
+data class FOCVoteMessage(val fileName: String, val focVote: FOCVote) :
+    Serializable,
     nl.tudelft.ipv8.messaging.Serializable {
     override fun serialize(): ByteArray {
         return serializeVarLen(fileName.toByteArray(Charsets.UTF_8)) +
@@ -25,13 +26,14 @@ data class FOCVoteMessage(val fileName: String, val focVote: FOCVote) : Serializ
             localOffset += midSize
             val (voteType, voteTypeSize) = deserializeVarLen(buffer, localOffset)
             localOffset += voteTypeSize
-            val payload = FOCVoteMessage(
-                fileName.toString(Charsets.UTF_8),
-                FOCVote(
-                    mid.toString(Charsets.UTF_8),
-                    VoteType.valueOf(voteType.toString(Charsets.UTF_8))
+            val payload =
+                FOCVoteMessage(
+                    fileName.toString(Charsets.UTF_8),
+                    FOCVote(
+                        mid.toString(Charsets.UTF_8),
+                        VoteType.valueOf(voteType.toString(Charsets.UTF_8))
+                    )
                 )
-            )
             return Pair(payload, localOffset - offset)
         }
     }

--- a/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCVoteMessage.kt
+++ b/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCVoteMessage.kt
@@ -1,19 +1,32 @@
 package nl.tudelft.trustchain.foc.community
 
 import nl.tudelft.ipv8.messaging.Deserializable
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
 import java.io.Serializable
 
-data class FOCVoteMessage(val fileName: String, val focVote: FOCVote) : Serializable, nl.tudelft.ipv8.messaging.Serializable {
+
+data class FOCVoteMessage(val fileName: String, val focVote: FOCVote) : Serializable,
+    nl.tudelft.ipv8.messaging.Serializable {
     override fun serialize(): ByteArray {
-        return this.serialize()
+        val byteArrayOutputStream = ByteArrayOutputStream()
+        val objectOutputStream = ObjectOutputStream(byteArrayOutputStream)
+        objectOutputStream.writeObject(this)
+        objectOutputStream.flush()
+        return byteArrayOutputStream.toByteArray()
     }
 
+    @Suppress("UNCHECKED_CAST")
     companion object Deserializer : Deserializable<FOCVoteMessage> {
         override fun deserialize(
             buffer: ByteArray,
             offset: Int
         ): Pair<FOCVoteMessage, Int> {
-            return this.deserialize(buffer)
+            val byteArrayInputStream = ByteArrayInputStream(buffer)
+            val objectInputStream = ObjectInputStream(byteArrayInputStream)
+            return objectInputStream.readObject() as Pair<FOCVoteMessage, Int>
         }
     }
 }

--- a/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCVoteMessage.kt
+++ b/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCVoteMessage.kt
@@ -26,7 +26,7 @@ data class FOCVoteMessage(val fileName: String, val focVote: FOCVote) : Serializ
         ): Pair<FOCVoteMessage, Int> {
             val byteArrayInputStream = ByteArrayInputStream(buffer)
             val objectInputStream = ObjectInputStream(byteArrayInputStream)
-            return objectInputStream.readObject() as Pair<FOCVoteMessage, Int>
+            return Pair(objectInputStream.readObject() as FOCVoteMessage, buffer.size)
         }
     }
 }

--- a/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCVoteTracker.kt
+++ b/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCVoteTracker.kt
@@ -77,7 +77,8 @@ class FOCVoteTracker(
         } else {
             voteMap[fileName] = hashSetOf(vote)
         }
-        focCommunity.informAboutVote(fileName, vote)
+        // Initial TTL set to 2
+        focCommunity.informAboutVote(fileName, vote, 2u)
     }
 
     /**

--- a/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCVoteTracker.kt
+++ b/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCVoteTracker.kt
@@ -2,6 +2,7 @@ package nl.tudelft.trustchain.foc.community
 
 import android.util.Log
 import android.widget.Toast
+import nl.tudelft.ipv8.messaging.Packet
 import nl.tudelft.trustchain.foc.MainActivityFOC
 import nl.tudelft.trustchain.foc.util.ExtensionUtils
 import java.io.ByteArrayInputStream
@@ -11,7 +12,9 @@ import java.io.IOException
 import java.io.ObjectInputStream
 import java.io.ObjectOutputStream
 
-class FOCVoteTracker(private val activity: MainActivityFOC) {
+class FOCVoteTracker(private val activity: MainActivityFOC,
+    private val focCommunity: FOCCommunityBase
+) {
     // Stores the votes for all apks
     private var voteMap: HashMap<String, HashSet<FOCVote>> = HashMap()
 
@@ -61,7 +64,18 @@ class FOCVoteTracker(private val activity: MainActivityFOC) {
         } else {
             voteMap[fileName] = hashSetOf(vote)
         }
+        // Gossip vote
+        focCommunity.informAboutVote(fileName, vote)
     }
+
+    fun insertVote(fileName: String, vote: FOCVote) {
+        if (voteMap.containsKey(fileName)) {
+            voteMap[fileName]!!.add(vote)
+        } else {
+            voteMap[fileName] = hashSetOf(vote)
+        }
+    }
+
 
     /**
      * Get the number of votes for an APK

--- a/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCVoteTracker.kt
+++ b/freedomOfComputing/src/main/java/nl/tudelft/trustchain/foc/community/FOCVoteTracker.kt
@@ -17,11 +17,12 @@ import java.io.ObjectInputStream
 import java.io.ObjectOutputStream
 
 class FOCVoteTracker(
-    private val activity: MainActivityFOC, private val focCommunity: FOCCommunity
+    private val activity: MainActivityFOC,
+    private val focCommunity: FOCCommunity
 ) {
     // Stores the votes for all apks
     private var voteMap: HashMap<String, HashSet<FOCVote>> = HashMap()
-    val GOSSIP_DELAY: Long = 1000
+    private val gossipDelay: Long = 1000
     private val scope = CoroutineScope(Dispatchers.IO)
 
     fun start() {
@@ -84,7 +85,10 @@ class FOCVoteTracker(
      * @param fileName APK on which vote is being placed
      * @param vote Vote that is being placed
      */
-    private fun insertVote(fileName: String, vote: FOCVote) {
+    private fun insertVote(
+        fileName: String,
+        vote: FOCVote
+    ) {
         if (voteMap.containsKey(fileName)) {
             voteMap[fileName]!!.add(vote)
         } else {
@@ -94,7 +98,6 @@ class FOCVoteTracker(
             activity.updateVoteCounts(fileName)
         }
     }
-
 
     /**
      * Get the number of votes for an APK
@@ -121,7 +124,7 @@ class FOCVoteTracker(
                 val (_, payload) = focCommunity.voteMessagesQueue.remove()
                 insertVote(payload.fileName, payload.focVote)
             }
-            delay(GOSSIP_DELAY)
+            delay(gossipDelay)
         }
     }
 

--- a/freedomOfComputing/src/main/res/values/ids.xml
+++ b/freedomOfComputing/src/main/res/values/ids.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="apkNameId" type="id" />
+    <item name="upVoteId" type="id" />
+    <item name="downVoteId" type="id" />
+</resources>

--- a/freedomOfComputing/src/test/java/nl/tudelft/trustchain/foc/FOCCommunityMock.kt
+++ b/freedomOfComputing/src/test/java/nl/tudelft/trustchain/foc/FOCCommunityMock.kt
@@ -9,8 +9,6 @@ import nl.tudelft.trustchain.foc.community.FOCVote
 import nl.tudelft.trustchain.foc.community.FOCVoteMessage
 import java.util.*
 
-@Suppress("deprecation")
-@OptIn(ExperimentalUnsignedTypes::class)
 class FOCCommunityMock(
     override val serviceId: String
 ) : FOCCommunityBase() {
@@ -60,7 +58,8 @@ class FOCCommunityMock(
 
     override fun informAboutVote(
         fileName: String,
-        vote: FOCVote
+        vote: FOCVote,
+        ttl: UInt
     ) {
     }
 

--- a/freedomOfComputing/src/test/java/nl/tudelft/trustchain/foc/FOCCommunityMock.kt
+++ b/freedomOfComputing/src/test/java/nl/tudelft/trustchain/foc/FOCCommunityMock.kt
@@ -5,6 +5,8 @@ import nl.tudelft.ipv8.messaging.eva.TransferException
 import nl.tudelft.ipv8.messaging.eva.TransferProgress
 import nl.tudelft.trustchain.foc.community.FOCCommunityBase
 import nl.tudelft.trustchain.foc.community.FOCMessage
+import nl.tudelft.trustchain.foc.community.FOCVote
+import nl.tudelft.trustchain.foc.community.FOCVoteMessage
 import java.util.*
 
 @Suppress("deprecation")
@@ -17,6 +19,7 @@ class FOCCommunityMock(
     }
 
     override var torrentMessagesList = ArrayList<Pair<Peer, FOCMessage>>()
+    override var voteMessagesQueue: Queue<Pair<Peer, FOCVoteMessage>> = LinkedList()
     var appRequests = ArrayList<Pair<String, Peer>>()
     var torrentsInformedAbout = ArrayList<String>()
 
@@ -53,6 +56,12 @@ class FOCCommunityMock(
 
     override fun informAboutTorrent(torrentName: String) {
         torrentsInformedAbout.add(torrentName)
+    }
+
+    override fun informAboutVote(
+        fileName: String,
+        vote: FOCVote
+    ) {
     }
 
     override fun sendAppRequest(


### PR DESCRIPTION
Issue: #29 
---

- Made it so that when a vote is placed we push gossip it to all peers
- Upon receiving a gossiped vote, add it to a queue
- Iteratively go through that queue and add those votes to the votetracker
- Implemented hot-potato gossip which sends a vote to log(n) of it's peers with an initial TTL of 2